### PR TITLE
Avoid space disappearance between options

### DIFF
--- a/templates/generic-command.cfg.erb
+++ b/templates/generic-command.cfg.erb
@@ -27,5 +27,5 @@ define command{
 define command{
   name          check-host-alive  
   command_name  check-host-alive
-  command_line  $USER1$/check_ping <%- if ( has_variable?("nagios_check_ping_ipv") and ( nagios_check_ping_ipv=="4" or nagios_check_ping_ipv=="6" ) ) -%>-<%=nagios_check_ping_ipv%> <%- end -%>-H $HOSTADDRESS$ -w 5000,100% -c 5000,100% -p 1
+  command_line  $USER1$/check_ping <%- if ( has_variable?("nagios_check_ping_ipv") and ( nagios_check_ping_ipv=="4" or nagios_check_ping_ipv=="6" ) ) -%>-<%=nagios_check_ping_ipv%> <% end -%>-H $HOSTADDRESS$ -w 5000,100% -c 5000,100% -p 1
 }


### PR DESCRIPTION
The problem shows up on rhel6.
This fix the problem on the template, I've to check if it's a bug or a feature with the new ruby/puppet version
