### PR TITLE
Add nrpe user definition

### DIFF
--- a/manifests/nrpe/client.pp
+++ b/manifests/nrpe/client.pp
@@ -27,6 +27,12 @@ class nagios::nrpe::client {
     name   => $package_name,
   }
 
+  user{ 'nrpe':
+    ensure  => present,
+    shell   => '/sbin/nologin',
+    require => Package['nrpe'],
+  }
+
   service { 'nrpe':
     ensure  => running,
     name    => $service_name,


### PR DESCRIPTION
It's creted by the package, but we need a definition in puppet of the user, to be able to manage it.
