### PR TITLE
Remove bad SELinux type for /var/run/nagios/

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -25,7 +25,6 @@ class nagios::redhat inherits nagios::base {
 
     '5','6': {
       File[
-        '/var/run/nagios',
         '/var/log/nagios',
         '/var/lib/nagios',
         '/var/lib/nagios/spool',


### PR DESCRIPTION
Already handled by RedHat policy (nagios_var_run_t)