### PR TITLE
Remove file context for RHEL7 too

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -85,10 +85,6 @@ class nagios::redhat inherits nagios::base {
     }
 
     '7': {
-      selinux::fcontext{ '/var/cache/nagios':
-        setype => 'nagios_log_t',
-      }
-
       Service['nagios'] {
         provider => 'systemd',
       }


### PR DESCRIPTION
RHEL policy set already set it to nagios_var_run_t, which is good.