### PR TITLE
Rename local nagios_host resources

### DIFF
--- a/manifests/host/nsca.pp
+++ b/manifests/host/nsca.pp
@@ -27,7 +27,7 @@ define nagios::host::nsca (
     default => $address,
   }
 
-  nagios_host { $name:
+  nagios_host { "Active ${name}":
     ensure  => $ensure,
     use     => 'generic-host-active',
     address => $nagios_host_address,
@@ -39,7 +39,7 @@ define nagios::host::nsca (
     ensure => $ensure,
     owner  => 'root',
     mode   => '0644',
-    before => Nagios_host[$name],
+    before => Nagios_host["Active ${name}"],
   }
 
   @@nagios_host { "@@${name}":

--- a/manifests/host/remote.pp
+++ b/manifests/host/remote.pp
@@ -28,7 +28,7 @@ define nagios::host::remote (
     default => $address,
   }
 
-  nagios_host { $name:
+  nagios_host { "Active ${name}":
     ensure  => $ensure,
     use     => 'generic-host-active',
     address => $host_address,
@@ -40,7 +40,7 @@ define nagios::host::remote (
     ensure => $ensure,
     owner  => 'root',
     mode   => '0644',
-    before => Nagios_host[$name],
+    before => Nagios_host["Active ${name}"],
   }
 
 


### PR DESCRIPTION
This is to avoid clash with host_name aliases on exported resource
which happens in Puppet 4.