### PR TITLE
Use namevar instead of alias

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -19,9 +19,9 @@ class nagios::debian inherits nagios::base {
     ]:
     ensure => installed,
   }
-  package {'nagios3-core':
+  package {'nagios':
     ensure => installed,
-    alias  => 'nagios',
+    name   => 'nagios3-core',
   }
 
   Service['nagios'] {


### PR DESCRIPTION
Aliases cannot be used to refer to resources in Puppet 4 anymore.