### PR TITLE
Realize the exported resource locally

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -150,7 +150,9 @@ class nagios::base {
 
   nagios_contact { 'root':
     contact_name                  => 'root',
+    # lint:ignore:alias_parameter
     alias                         => 'Root',
+    # lint:endignore
     service_notification_period   => '24x7',
     host_notification_period      => '24x7',
     service_notification_options  => 'w,u,c,r',
@@ -171,7 +173,9 @@ class nagios::base {
 
   nagios_contactgroup { 'admins':
     contactgroup_name => 'admins',
+    # lint:ignore:alias_parameter
     alias             => 'Nagios Administrators',
+    # lint:endignore
     members           => 'root',
     target            => "${nagios::params::resourcedir}/base-contactgroups.cfg",
     notify            => Exec['nagios-restart'],
@@ -188,7 +192,9 @@ class nagios::base {
   }
 
   nagios_servicegroup { 'default':
+    # lint:ignore:alias_parameter
     alias   => 'Default Service Group',
+    # lint:endignore
     target  => "${nagios::params::resourcedir}/base-servicegroup.cfg",
     notify  => Exec['nagios-restart'],
     require => File["${nagios::params::resourcedir}/base-servicegroup.cfg"],

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -28,7 +28,9 @@ define nagios::host (
     ensure         => $ensure,
     use            => 'generic-host-active',
     address        => $nagios_address,
+    # lint:ignore:alias_parameter
     alias          => $nagios_alias,
+    # lint:endignore
     hostgroups     => $hostgroups,
     contact_groups => $contact_groups,
     target         => "${nagios::params::resourcedir}/host-${fname}.cfg",

--- a/manifests/host/nsca.pp
+++ b/manifests/host/nsca.pp
@@ -31,10 +31,10 @@ define nagios::host::nsca (
     ensure => $ensure,
     owner  => 'root',
     mode   => '0644',
-    before => Nagios_host[$name],
+    before => Nagios_host["@@${name}"],
   }
 
-  @@nagios_host { $name:
+  @@nagios_host { "@@${name}":
     ensure         => $ensure,
     use            => 'generic-host-passive',
     address        => $nagios_host_address,
@@ -47,7 +47,7 @@ define nagios::host::nsca (
     notify         => Exec['nagios-restart'],
   }
 
-  Nagios_host <<| title == $name |>> {
+  Nagios_host <<| title == "@@${name}" |>> {
     use            => 'generic-host-active',
     target         => "${nagios::params::resourcedir}/host-${fname}.cfg",
     tag            => undef,

--- a/manifests/host/nsca.pp
+++ b/manifests/host/nsca.pp
@@ -27,22 +27,14 @@ define nagios::host::nsca (
     default => $address,
   }
 
-  nagios_host { "Active ${name}":
-    ensure  => $ensure,
-    use     => 'generic-host-active',
-    address => $nagios_host_address,
-    target  => "${nagios::params::resourcedir}/host-${fname}.cfg",
-    notify  => Exec['nagios-restart'],
-  }
-
   file { "${nagios::params::resourcedir}/host-${fname}.cfg":
     ensure => $ensure,
     owner  => 'root',
     mode   => '0644',
-    before => Nagios_host["Active ${name}"],
+    before => Nagios_host[$name],
   }
 
-  @@nagios_host { "@@${name}":
+  @@nagios_host { $name:
     ensure         => $ensure,
     use            => 'generic-host-passive',
     address        => $nagios_host_address,
@@ -53,6 +45,14 @@ define nagios::host::nsca (
     target         => "${nagios::params::resourcedir}/collected-host-${fname}.cfg",
     contact_groups => $contact_groups,
     notify         => Exec['nagios-restart'],
+  }
+
+  Nagios_host <<| title == $name |>> {
+    use            => 'generic-host-active',
+    target         => "${nagios::params::resourcedir}/host-${fname}.cfg",
+    tag            => undef,
+    hostgroups     => undef,
+    contact_groups => undef,
   }
 
   @@file { "${nagios::params::resourcedir}/collected-host-${fname}.cfg":

--- a/manifests/host/nsca.pp
+++ b/manifests/host/nsca.pp
@@ -39,7 +39,9 @@ define nagios::host::nsca (
     use            => 'generic-host-passive',
     address        => $nagios_host_address,
     host_name      => $name,
+    # lint:ignore:alias_parameter
     alias          => $nagios_alias,
+    # lint:endignore
     tag            => $export_for,
     hostgroups     => $hostgroups,
     target         => "${nagios::params::resourcedir}/collected-host-${fname}.cfg",

--- a/manifests/host/remote.pp
+++ b/manifests/host/remote.pp
@@ -28,14 +28,6 @@ define nagios::host::remote (
     default => $address,
   }
 
-  nagios_host { "Active ${name}":
-    ensure  => $ensure,
-    use     => 'generic-host-active',
-    address => $host_address,
-    target  => "${nagios::params::resourcedir}/host-${fname}.cfg",
-    notify  => Exec['nagios-restart'],
-  }
-
   file { "${nagios::params::resourcedir}/host-${fname}.cfg":
     ensure => $ensure,
     owner  => 'root',
@@ -44,7 +36,7 @@ define nagios::host::remote (
   }
 
 
-  @@nagios_host { "@@${name}":
+  @@nagios_host { $name:
     ensure         => $ensure,
     use            => 'generic-host-active',
     tag            => $export_for,
@@ -55,6 +47,14 @@ define nagios::host::remote (
     contact_groups => $contact_groups,
     target         => "${nagios::params::resourcedir}/collected-host-${fname}.cfg",
     notify         => Exec['nagios-restart'],
+  }
+
+  Nagios_host <<| title == $name |>> {
+    use => 'generic-host-active',
+    target  => "${nagios::params::resourcedir}/host-${fname}.cfg",
+    tag            => undef,
+    hostgroups     => undef,
+    contact_groups => undef,
   }
 
   @@file { "${nagios::params::resourcedir}/collected-host-${fname}.cfg":

--- a/manifests/host/remote.pp
+++ b/manifests/host/remote.pp
@@ -42,7 +42,9 @@ define nagios::host::remote (
     tag            => $export_for,
     host_name      => $name,
     address        => $host_address,
+    # lint:ignore:alias_parameter
     alias          => $nagios_alias,
+    # lint:endignore
     hostgroups     => $hostgroups,
     contact_groups => $contact_groups,
     target         => "${nagios::params::resourcedir}/collected-host-${fname}.cfg",

--- a/manifests/host/remote.pp
+++ b/manifests/host/remote.pp
@@ -32,11 +32,11 @@ define nagios::host::remote (
     ensure => $ensure,
     owner  => 'root',
     mode   => '0644',
-    before => Nagios_host["Active ${name}"],
+    before => Nagios_host["@@${name}"],
   }
 
 
-  @@nagios_host { $name:
+  @@nagios_host { "@@${name}":
     ensure         => $ensure,
     use            => 'generic-host-active',
     tag            => $export_for,
@@ -49,7 +49,7 @@ define nagios::host::remote (
     notify         => Exec['nagios-restart'],
   }
 
-  Nagios_host <<| title == $name |>> {
+  Nagios_host <<| title == "@@${name}" |>> {
     use => 'generic-host-active',
     target  => "${nagios::params::resourcedir}/host-${fname}.cfg",
     tag            => undef,


### PR DESCRIPTION
The local and server resources actually need to use
the same host_name, which leads to duplicate resource
titles or aliases.

The only way out I found is to use only one resource,
export it, and then realize it locally forcing parameters.