### PR TITLE
Stop managing files created by nagios

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -51,23 +51,6 @@ class nagios::redhat inherits nagios::base {
         pattern     => '/usr/sbin/nagios -d /etc/nagios/nagios.cfg',
       }
 
-      file {[
-        '/var/lib/nagios/retention.dat',
-        '/var/cache/nagios/nagios.tmp',
-        '/var/cache/nagios/status.dat',
-        '/var/cache/nagios/objects.precache',
-        '/var/cache/nagios/objects.cache',
-      ]:
-        ensure   => file,
-        seltype  => 'nagios_log_t',
-        owner    => 'nagios',
-        group    => 'nagios',
-        loglevel => 'debug',
-        require  => File['/var/run/nagios'],
-      }
-      File['/var/lib/nagios/retention.dat'] { mode => '0600', }
-      File['/var/cache/nagios/status.dat']  { mode => '0664', }
-
       # workaround broken init-script
       Exec['nagios-restart'] {
         command => "nagios -v ${nagios::params::conffile} && pkill -P 1 -f '^/usr/sbin/nagios' && /etc/init.d/nagios start",


### PR DESCRIPTION
This is the source of our constantly "active" puppet runs (selinux user change from `undefined_u` to `system_u`). And since these
files are managed by nagios itself, there's really no good reason to have
puppet create them or change any permission.

I don't know for what weird historical reason this was done like that, maybe
just overzealousness. Let's try without managing these files for a while and
see if we hit any problem.