### PR TITLE
Add rw dir in /var/log/nagios for nagios 4

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -55,6 +55,15 @@ class nagios::base {
     require => Package['nagios'],
   }
 
+  file { 'nagios query-handler read-write dir':
+    ensure  => directory,
+    path    => "/var/log/${nagios::params::basename}/rw",
+    owner   => 'nagios',
+    group   => 'nagios',
+    mode    => '2710',
+    require => Package['nagios'],
+  }
+
   file {[
     "/var/run/${nagios::params::basename}",
     "/var/log/${nagios::params::basename}",


### PR DESCRIPTION
Nagios 4 uses a second rw directory for a 'query handler' socket.