### PR TITLE
Make nagios run correctly on RHEL7 with latest EPEL nagios

### DIFF
--- a/manifests/nrpe/client.pp
+++ b/manifests/nrpe/client.pp
@@ -38,12 +38,6 @@ class nagios::nrpe::client {
     require => Package['nrpe'],
   }
 
-  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7' {
-    $provider = 'redhat'
-  } else {
-    $provider = undef
-  }
-
   if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease == '6' {
     $hasstatus = false
   } else {
@@ -52,7 +46,6 @@ class nagios::nrpe::client {
 
   service { 'nrpe':
     ensure    => running,
-    provider  => $provider,
     hasstatus => $hasstatus,
     name      => $service_name,
     enable    => true,

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -55,10 +55,6 @@ class nagios::redhat inherits nagios::base {
     }
 
     '7': {
-      Service['nagios'] {
-        provider => 'redhat',
-      }
-
       Exec['nagios-restart'] {
         command => "nagios -v ${nagios::params::conffile} && systemctl restart nagios.service",
       }
@@ -67,6 +63,13 @@ class nagios::redhat inherits nagios::base {
         command => "nagios -v ${nagios::params::conffile} && systemctl reload nagios.service",
       }
 
+      file {'/var/log/nagios/nagios.log':
+        ensure  => file,
+        owner   => 'nagios',
+        group   => 'nagios',
+        require => Package['nagios'],
+        before  => Service['nagios'],
+      }
     }
 
     default: {


### PR DESCRIPTION
Remove override for service provider since the default should work as-is
Add correct owner for nagios.log file so that nagios service starts at first puppet run.